### PR TITLE
audit: fix Ultimate Bundle card layout on packages page

### DIFF
--- a/custom.css
+++ b/custom.css
@@ -2087,3 +2087,17 @@ FAQ / DOCS / ABOUT / CONTACT — Card polish
     height: auto !important;
   }
 }
+
+/* === AUDIT FIXES (May 2026) === */
+
+/* Packages page: when Ultimate Bundle is the 6th/last card sitting alone on a row, center it with a sane width so it doesn't leave dead space */
+@media (min-width: 769px) {
+  .packages-grid > .package-card:nth-child(6):last-child {
+      grid-column: 1 / -1;
+          max-width: 460px;
+              justify-self: center;
+                  margin-left: auto;
+                      margin-right: auto;
+                        }
+                        }
+                                        


### PR DESCRIPTION
## Summary

Fixes the visual bug on packages.html where the Ultimate Bundle card sits alone on a second row inside a 5-column grid, leaving 4 empty cells of dead space to its right.

## Change

Adds a CSS-only rule in `custom.css`:
- When the bundle is the 6th and last card in `.packages-grid` on desktop (≥769px), it now spans the full row and centers itself with a `max-width: 460px`.
## Safety

- CSS-only change, scoped to `:nth-child(6):last-child` on the packages grid.
- - No HTML, JS, or business-logic changes.
- - Backup branch `backup-before-audit-may2026` was created from main prior to any edits.
- - Verified working live by injecting the rule into the production page and confirming the bundle card now centers cleanly below the 5-card row.
- 